### PR TITLE
Jellyfin 10.6 compatability changes

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Configuration/configPage.html
+++ b/Jellyfin.Plugin.YoutubeMetadata/Configuration/configPage.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>YoutubeMetadata</title>
+    <title>YouTube Metadata</title>
 </head>
 <body>
     <div id="YoutubeMetadataConfigPage" data-role="page" class="page type-interior pluginConfigurationPage" data-require="emby-input,emby-button,emby-select,emby-checkbox">

--- a/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
+++ b/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
@@ -30,7 +30,7 @@
 	  <PackageReference Include="Google.Apis.YouTube.v3" Version="1.45.0.1905">
 	    <IncludeAssets></IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Jellyfin.Controller" Version="10.6.*-*">
+	  <PackageReference Include="Jellyfin.Controller" Version="10.*-*">
 	    <IncludeAssets>compile</IncludeAssets>
 	  </PackageReference>
 	</ItemGroup>

--- a/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
+++ b/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
@@ -3,8 +3,8 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<RootNamespace>Jellyfin.Plugin.YoutubeMetadata</RootNamespace>
-		<AssemblyVersion>1.0.2.0</AssemblyVersion>
-		<FileVersion>1.0.2.0</FileVersion>
+		<AssemblyVersion>1.0.2.1</AssemblyVersion>
+		<FileVersion>1.0.2.1</FileVersion>
 		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
 		<Version>1.0.2.1</Version>
 	</PropertyGroup>
@@ -30,7 +30,7 @@
 	  <PackageReference Include="Google.Apis.YouTube.v3" Version="1.45.0.1905">
 	    <IncludeAssets></IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="Jellyfin.Controller" Version="10.5.2">
+	  <PackageReference Include="Jellyfin.Controller" Version="10.6.*-*">
 	    <IncludeAssets>compile</IncludeAssets>
 	  </PackageReference>
 	</ItemGroup>

--- a/Jellyfin.Plugin.YoutubeMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Plugin.cs
@@ -10,7 +10,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
 {
     public class Plugin : BasePlugin<PluginConfiguration>, IHasWebPages
     {
-        public override string Name => "YoutubeMetadata";
+        public override string Name => "YouTube Metadata";
 
         public override Guid Id => Guid.Parse("b4b4353e-dc57-4398-82c1-de9079e7146a");
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer) : base(applicationPaths, xmlSerializer)

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/CreatorProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/CreatorProvider.cs
@@ -38,7 +38,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             return item is Person;
         }
 
-        public string Name => "YoutubeMetadata";
+        public string Name => "YouTube Metadata";
 
         public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
         {
@@ -85,7 +85,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                 }
             }
             //return Task.FromResult<IEnumerable<RemoteImageInfo>>(infos);
-            
+
             return infos;
         }
         internal Task EnsureInfo(string channelId, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeLocalImageProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeLocalImageProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Jellyfin.Plugin.YoutubeMetadata.Providers
 {
-    public class YoutubeLocalImageProvider : ILocalImageFileProvider, IHasOrder
+    public class YoutubeLocalImageProvider : ILocalImageProvider, IHasOrder
     {
         private readonly IFileSystem _fileSystem;
         private readonly ILogger _logger;
@@ -20,7 +20,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             _logger = logger;
         }
         // This does not look neccesary?
-        public string Name => "YoutubeMetadata";
+        public string Name => "YouTube Metadata";
         public int Order => 1;
         public List<LocalImageInfo> GetImages(BaseItem item, IDirectoryService directoryService)
         {

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeLocalImageProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeLocalImageProvider.cs
@@ -12,9 +12,9 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
     public class YoutubeLocalImageProvider : ILocalImageProvider, IHasOrder
     {
         private readonly IFileSystem _fileSystem;
-        private readonly ILogger _logger;
+        private readonly ILogger<YoutubeLocalImageProvider> _logger;
 
-        public YoutubeLocalImageProvider(IServerConfigurationManager config, IFileSystem fileSystem, ILogger logger)
+        public YoutubeLocalImageProvider(IServerConfigurationManager config, IFileSystem fileSystem, ILogger<YoutubeLocalImageProvider> logger)
         {
             _fileSystem = fileSystem;
             _logger = logger;

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeLocalProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeLocalProvider.cs
@@ -25,11 +25,11 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
     }
     public class YoutubeLocalProvider : ILocalMetadataProvider<Movie>, IHasItemChangeMonitor
     {
-        private readonly ILogger _logger;
+        private readonly ILogger<YoutubeLocalProvider> _logger;
         private readonly IJsonSerializer _json;
         private readonly IFileSystem _fileSystem;
 
-        public YoutubeLocalProvider(IFileSystem fileSystem, IJsonSerializer json, ILogger logger)
+        public YoutubeLocalProvider(IFileSystem fileSystem, IJsonSerializer json, ILogger<YoutubeLocalProvider> logger)
         {
             _fileSystem = fileSystem;
             _logger = logger;

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeLocalProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeLocalProvider.cs
@@ -36,7 +36,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             _json = json;
         }
 
-        public string Name => "YoutubeMetadata";
+        public string Name => "YouTube Metadata";
 
         private FileSystemMetadata GetInfoJson(string path)
         {
@@ -80,7 +80,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                 result.HasMetadata = false;
                 return Task.FromResult(result);
             }
-            
+
         }
 
         private MovieJson ReadJsonData(MetadataResult<Movie> movieResult, string metaFile, CancellationToken cancellationToken)

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeMetadataImageProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeMetadataImageProvider.cs
@@ -18,10 +18,10 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         private readonly IServerConfigurationManager _config;
         private readonly IHttpClient _httpClient;
         private readonly IJsonSerializer _json;
-        private readonly ILogger _logger;
+        private readonly ILogger<YoutubeMetadataImageProvider> _logger;
         public static YoutubeMetadataProvider Current;
 
-        public YoutubeMetadataImageProvider(IServerConfigurationManager config, IHttpClient httpClient, IJsonSerializer json, ILogger logger)
+        public YoutubeMetadataImageProvider(IServerConfigurationManager config, IHttpClient httpClient, IJsonSerializer json, ILogger<YoutubeMetadataImageProvider> logger)
         {
             _config = config;
             _httpClient = httpClient;

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeMetadataImageProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeMetadataImageProvider.cs
@@ -30,7 +30,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         }
 
         /// <inheritdoc />
-        public string Name => "YoutubeMetadata";
+        public string Name => "YouTube Metadata";
 
         /// <inheritdoc />
         // After embedded and fanart
@@ -62,9 +62,9 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                 if (obj != null)
                 {
                     var tnurls = new List<string>();
-                    if (obj.Snippet.Thumbnails.Maxres != null) { 
+                    if (obj.Snippet.Thumbnails.Maxres != null) {
                         tnurls.Add(obj.Snippet.Thumbnails.Maxres.Url);
-                    } 
+                    }
                     if (obj.Snippet.Thumbnails.Standard != null)
                     {
                         tnurls.Add(obj.Snippet.Thumbnails.Standard.Url);
@@ -88,7 +88,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
 
             return new List<RemoteImageInfo>();
         }
-        
+
         private IEnumerable<RemoteImageInfo> GetImages(IEnumerable<string> urls)
         {
             var list = new List<RemoteImageInfo>();

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeMusicProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeMusicProvider.cs
@@ -21,7 +21,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         private readonly IFileSystem _fileSystem;
         private readonly IHttpClient _httpClient;
         private readonly IJsonSerializer _json;
-        private readonly ILogger _logger;
+        private readonly ILogger<YoutubeMusicProvider> _logger;
         private readonly ILibraryManager _libmanager;
 
         public static YoutubeMetadataProvider Current;
@@ -29,7 +29,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public const string BaseUrl = "https://m.youtube.com/";
         public const string YTID_RE = @"(?<=\[)[a-zA-Z0-9\-_]{11}(?=\])";
 
-        public YoutubeMusicProvider(IServerConfigurationManager config, IFileSystem fileSystem, IHttpClient httpClient, IJsonSerializer json, ILogger logger, ILibraryManager libmanager)
+        public YoutubeMusicProvider(IServerConfigurationManager config, IFileSystem fileSystem, IHttpClient httpClient, IJsonSerializer json, ILogger<YoutubeMusicProvider> logger, ILibraryManager libmanager)
         {
             _config = config;
             _fileSystem = fileSystem;

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeMusicProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeMusicProvider.cs
@@ -40,7 +40,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         }
 
         /// <inheritdoc />
-        public string Name => "YoutubeMetadata";
+        public string Name => "YouTube Metadata";
 
         /// <inheritdoc />
         public int Order => 1;

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeProvider.cs
@@ -29,7 +29,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         private readonly IFileSystem _fileSystem;
         private readonly IHttpClient _httpClient;
         private readonly IJsonSerializer _json;
-        private readonly ILogger _logger;
+        private readonly ILogger<YoutubeMetadataProvider> _logger;
         private readonly ILibraryManager _libmanager;
 
         public static YoutubeMetadataProvider Current;
@@ -37,7 +37,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public const string BaseUrl = "https://m.youtube.com/";
         public const string YTID_RE = @"(?<=\[)[a-zA-Z0-9\-_]{11}(?=\])";
 
-        public YoutubeMetadataProvider(IServerConfigurationManager config, IFileSystem fileSystem, IHttpClient httpClient, IJsonSerializer json, ILogger logger, ILibraryManager libmanager)
+        public YoutubeMetadataProvider(IServerConfigurationManager config, IFileSystem fileSystem, IHttpClient httpClient, IJsonSerializer json, ILogger<YoutubeMetadataProvider> logger, ILibraryManager libmanager)
         {
             _config = config;
             _fileSystem = fileSystem;

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeProvider.cs
@@ -49,7 +49,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         }
 
         /// <inheritdoc />
-        public string Name => "YoutubeMetadata";
+        public string Name => "YouTube Metadata";
 
         /// <inheritdoc />
         public int Order => 1;

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,19 @@
+---
+name: "YouTube Metadata"
+guid: "b4b4353e-dc57-4398-82c1-de9079e7146a"
+version: "1.0.2.1"
+targetAbi: "10.6.0.0"
+owner: "ankenyr"
+overview: "YouTube metadata provider"
+description: "Provides YouTube metadata from the YouTube API and Youtube-dl metadata files."
+category: "Metadata"
+artifacts:
+- "Jellyfin.Plugin.YoutubeMetadata.dll"
+- "Newtonsoft.Json.dll"
+- "Google.Apis.dll"
+- "Google.Apis.Core.dll"
+- "Google.Apis.Auth.dll"
+- "Google.Apis.Auth.PlatformServices.dll"
+- "Google.Apis.YouTube.v3.dll"
+changelog: >
+  changelog


### PR DESCRIPTION
Changes required to compile this plugin against current 10.6 unstable.
The `YoutubeMetadata` -> `YouTube Metadata` name change is in line with what has been done for the official plugins.