### PR TITLE
Fix local metadata exiting if file already exists

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/AbstractYoutubeLocalProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/AbstractYoutubeLocalProvider.cs
@@ -65,7 +65,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             _logger.LogDebug("YTLocal GetMetadata: {Path}", info.Path);
             var result = new MetadataResult<T>();
             var infoFile = Path.ChangeExtension(info.Path, "info.json");
-            if (File.Exists(infoFile))
+            if (!File.Exists(infoFile))
             {
                 return Task.FromResult(result);
             }


### PR DESCRIPTION
Is this logic correct? Sorry, I am not too involved with the project, so unsure.

Here's the git blame: https://github.com/ankenyr/jellyfin-youtube-metadata-plugin/commit/93f4b2784bca74133f7b9ad08c358ba4f608cff0