### PR TITLE
Fixed Exceptions

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/AbstractYoutubeLocalProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/AbstractYoutubeLocalProvider.cs
@@ -70,8 +70,11 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                 return Task.FromResult(result);
             }
             var jsonObj = Utils.ReadYTDLInfo(infoFile, cancellationToken);
-            _logger.LogDebug("YTLocal GetMetadata Result: {JSON}", jsonObj.ToString());
-            result = this.GetMetadataImpl(jsonObj);
+            if (jsonObj != null)
+            {
+                _logger.LogDebug("YTLocal GetMetadata Result: {JSON}", jsonObj.ToString());
+                result = this.GetMetadataImpl(jsonObj);
+            }
 
             return Task.FromResult(result);
         }

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/AbstractYoutubeRemoteProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/AbstractYoutubeRemoteProvider.cs
@@ -107,21 +107,6 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             return Path.Combine(dataPath, "ytvideo.info.json");
         }
 
-        /// <summary>
-        /// Reads JSON data from file.
-        /// </summary>
-        /// <param name="metaFile"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        public YTDLData ReadYTDLInfo(string fpath, CancellationToken cancellationToken)
-        {
-            _logger.LogDebug("YTDL ReadYTDLInfo: {Path}", fpath);
-            cancellationToken.ThrowIfCancellationRequested();
-            string jsonString = _afs.File.ReadAllText(fpath);
-            var json = JsonSerializer.Deserialize<YTDLData>(jsonString);
-            return json;
-        }
-
         public virtual async Task<MetadataResult<T>> GetMetadata(E info, CancellationToken cancellationToken)
         {
             _logger.LogDebug("YTDL GetMetadata: {Path}", info.Path);
@@ -140,7 +125,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                 _logger.LogDebug("YTDL GetMetadata: Not Fresh: {ID}", id);
                 await this.GetAndCacheMetadata(id, this._config.ApplicationPaths, cancellationToken);
             }
-            var video = ReadYTDLInfo(ytPath, cancellationToken);
+            var video = Utils.ReadYTDLInfo(ytPath, cancellationToken);
             if (video != null)
             {
                 _logger.LogDebug("YTDL GetMetadata: Calling Impl function: {ID}", id);

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/YTDLSeriesProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/YTDLSeriesProvider.cs
@@ -54,7 +54,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                 _logger.LogDebug("YTDLSeries GetMetadata: {info.Name} is not fresh.", fileInfo.Name);
                 await this.GetAndCacheMetadata(name, this._config.ApplicationPaths, cancellationToken);
             }
-            var video = ReadYTDLInfo(ytPath, cancellationToken);
+            var video = Utils.ReadYTDLInfo(ytPath, cancellationToken);
             if (video != null)
             {
                 try

--- a/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
@@ -174,8 +174,16 @@ namespace Jellyfin.Plugin.YoutubeMetadata
         public static YTDLData ReadYTDLInfo(string fpath, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            string jsonString = File.ReadAllText(fpath);
-            return JsonSerializer.Deserialize<YTDLData>(jsonString);
+            try
+            {
+                string jsonString = File.ReadAllText(fpath);
+                return JsonSerializer.Deserialize<YTDLData>(jsonString);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+            
         }
 
         /// <summary>


### PR DESCRIPTION
Local Plugin was executed on all Libraries which resulted in a "FileNotFoundException" and "DirectoryNotFoundException" because the info.json was not available.
I removed a duplicate ReadYTDLInfo Method and added a catch to handle the Exceptions.