### PR TITLE
Added ProviderId for LocalProvider & Added optional support for alternative id format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ UpgradeLog*.XML
 # MonoDevelop metafiles
 MediaBrowser.Plugins.Anime.userprefs
 
+# vscode
+.vscode/

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Entities.Movies;
 using System;
+using System.IO;
 
 namespace Jellyfin.Plugin.YoutubeMetadata.Tests
 {
@@ -18,13 +19,13 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
     {
         [Theory]
         [InlineData("3Blue1Brown - 20190113 - The_most_unexpected_answer_to_a_counting_puzzle [HEfHFsfGXjs].mkv", "HEfHFsfGXjs")]
+        [InlineData("3Blue1Brown - 20190113 - The_most_unexpected_answer_to_a_counting_puzzle [youtube-HEfHFsfGXjs].mkv", "HEfHFsfGXjs")]
         [InlineData("Foo", "")]
         [InlineData("3Blue1Brown - NA - 3Blue1Brown_-_Videos [UCYO_jab_esuFRV4b17AJtAw].info.json", "UCYO_jab_esuFRV4b17AJtAw")]
+        [InlineData("3Blue1Brown - NA - 3Blue1Brown_-_Videos [youtube-UCYO_jab_esuFRV4b17AJtAw].info.json", "UCYO_jab_esuFRV4b17AJtAw")]
         public void GetYTIDTest(string fn, string expected)
         {
             Assert.Equal(expected, Utils.GetYTID(fn));
-
-
         }
 
         [Fact]
@@ -40,21 +41,24 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
         public void GetVideoInfoPathTest()
         {
             var mockAppPath = Mock.Of<IServerApplicationPaths>(a =>
-            a.CachePath == @"\foo\bar");
-            
+            a.CachePath == Path.Combine("foo", "bar").ToString()
+            );
+
             var result = Utils.GetVideoInfoPath(mockAppPath, "id123");
-            Assert.Equal(@"\foo\bar\youtubemetadata\id123\ytvideo.info.json", result);
+            Assert.Equal(Path.Combine("foo", "bar", "youtubemetadata", "id123", "ytvideo.info.json").ToString(), result);
         }
 
         [Fact]
         public void YTDLJsonToMovieTest()
         {
-            var data = new YTDLData {
+            var data = new YTDLData
+            {
                 title = "Foo",
                 description = "Some cool movie!",
                 upload_date = "20220131",
                 uploader = "SomeGuyIKnow",
-                channel_id = "ABCDEFGHIJKLMNOPQRSTUVWX" };
+                channel_id = "ABCDEFGHIJKLMNOPQRSTUVWX"
+            };
             var result = Utils.YTDLJsonToMovie(data);
             var person = new PersonInfo
             {

--- a/Jellyfin.Plugin.YoutubeMetadata/Constants.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Constants.cs
@@ -7,8 +7,8 @@
         public const string ChannelUrl = "https://www.youtube.com/channel/{0}";
         public const string VideoUrl = "https://www.youtube.com/watch?v={0}";
         public const string SearchQuery = "https://www.youtube.com/results?search_query={0}&sp=EgIQAg%253D%253D";
-
-        public const string YTCHANNEL_RE = @"(?<=\[)[a-zA-Z0-9\-_]{24}(?=\])";
-        public const string YTID_RE = @"(?<=\[)[a-zA-Z0-9\-_]{11}(?=\])";
+        // YouTube Channels always start with UC. 
+        public const string YTCHANNEL_RE = @"(?<=\[)(?:youtube-)?(?<id>UC[a-zA-Z0-9\-_]{22})(?=\])";
+        public const string YTID_RE = @"(?<=\[)(?:youtube-)?(?<id>[a-zA-Z0-9\-_]{11})(?=\])";
     }
 }

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/ExternalId/YTExternalId.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/ExternalId/YTExternalId.cs
@@ -12,34 +12,25 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers.ExternalId
         public bool Supports(IHasProviderIds item)
             => item is Movie || item is Episode || item is MusicVideo;
 
-        public string ProviderName
-            => Constants.PluginName;
+        public string ProviderName => Constants.PluginName;
 
-        public string Key
-            => Constants.PluginName;
+        public string Key => Constants.PluginName;
 
-        public ExternalIdMediaType? Type
-            => null;
+        public ExternalIdMediaType? Type => null;
 
-        public string UrlFormatString
-            => Constants.VideoUrl;
+        public string UrlFormatString => Constants.VideoUrl;
     }
 
     public class YTSeriesExternalId : IExternalId
     {
-        public bool Supports(IHasProviderIds item)
-            => item is Series;
+        public bool Supports(IHasProviderIds item) => item is Series;
 
-        public string ProviderName
-            => Constants.PluginName;
+        public string ProviderName => Constants.PluginName;
 
-        public string Key
-            => Constants.PluginName;
+        public string Key => Constants.PluginName;
 
-        public ExternalIdMediaType? Type
-            => null;
+        public ExternalIdMediaType? Type => null;
 
-        public string UrlFormatString
-            => Constants.ChannelUrl;
+        public string UrlFormatString => Constants.ChannelUrl;
     }
 }

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/AbstractYoutubeLocalProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/AbstractYoutubeLocalProvider.cs
@@ -65,7 +65,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             _logger.LogDebug("YTLocal GetMetadata: {Path}", info.Path);
             var result = new MetadataResult<T>();
             var infoFile = Path.ChangeExtension(info.Path, "info.json");
-            if (File.Exists(infoFile))
+            if (!File.Exists(infoFile))
             {
                 return Task.FromResult(result);
             }

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/YoutubeLocalImageProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/YoutubeLocalImageProvider.cs
@@ -28,16 +28,25 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public string Name => Constants.PluginName;
 
         public int Order => 1;
+
+        /// <summary>
+        /// Returns boolean based on support of item.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public bool Supports(BaseItem item) => item is Movie || item is Episode || item is MusicVideo;
+
         private string GetSeriesInfo(string path)
         {
             _logger.LogDebug("YTLocalImage GetSeriesInfo: {Path}", path);
             Matcher matcher = new();
+            Regex rx = new Regex(Constants.YTID_RE, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             matcher.AddInclude("*.jpg");
             matcher.AddInclude("*.webp");
             string infoPath = "";
             foreach (string file in matcher.GetResultsInFullPath(path))
             {
-                if (Regex.Match(file, Constants.YTID_RE).Success)
+                if (rx.IsMatch(file))
                 {
                     infoPath = file;
                     break;
@@ -61,23 +70,11 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             {
                 return list;
             }
-            if (String.IsNullOrEmpty(jpgPath))
-            {
-                return list;
-            }
             var localimg = new LocalImageInfo();
             var fileInfo = _fileSystem.GetFileSystemInfo(jpgPath);
             localimg.FileInfo = fileInfo;
             list.Add(localimg);
             return list;
         }
-
-        /// <summary>
-        /// Returns boolean based on support of item.
-        /// </summary>
-        /// <param name="item"></param>
-        /// <returns></returns>
-        public bool Supports(BaseItem item)
-            => item is Movie || item is Episode || item is MusicVideo;
     }
 }

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/YoutubeLocalSeriesImageProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/YoutubeLocalSeriesImageProvider.cs
@@ -15,26 +15,33 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers.LocalMetadata
         private readonly IFileSystem _fileSystem;
         private readonly ILogger<YoutubeLocalImageProvider> _logger;
 
+        /// <summary>
+        /// Providers name, this does not appear in the library metadata settings.
+        /// </summary>
+        public string Name => Constants.PluginName;
+
         public YoutubeLocalSeriesImageProvider(IFileSystem fileSystem, ILogger<YoutubeLocalImageProvider> logger)
         {
             _fileSystem = fileSystem;
             _logger = logger;
         }
-
         /// <summary>
-        /// Providers name, this does not appear in the library metadata settings.
+        /// Returns boolean based on support of item.
         /// </summary>
-        public string Name => Constants.PluginName;
+        /// <param name="item"></param>
+        /// <returns></returns>
+        public bool Supports(BaseItem item) => item is Series;
         private string GetSeriesInfo(string path)
         {
             _logger.LogDebug("YTLocalImageSeries GetSeriesInfo: {Path}", path);
             Matcher matcher = new();
             matcher.AddInclude("**/*.jpg");
             matcher.AddInclude("**/*.webp");
+            Regex rx = new Regex(Constants.YTCHANNEL_RE, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             string infoPath = "";
             foreach (string file in matcher.GetResultsInFullPath(path))
             {
-                if (Regex.Match(file, Constants.YTCHANNEL_RE).Success)
+                if (rx.IsMatch(file))
                 {
                     infoPath = file;
                     break;
@@ -66,12 +73,5 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers.LocalMetadata
             return list;
         }
 
-        /// <summary>
-        /// Returns boolean based on support of item.
-        /// </summary>
-        /// <param name="item"></param>
-        /// <returns></returns>
-        public bool Supports(BaseItem item)
-            => item is Series;
     }
 }

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/YoutubeLocalSeriesProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/LocalMetadata/YoutubeLocalSeriesProvider.cs
@@ -23,16 +23,16 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers.LocalMetadata
         }
         public string Name => Constants.PluginName;
 
-
         private string GetSeriesInfo(string path)
         {
             _logger.LogDebug("YTLocalSeries GetSeriesInfo: {Path}", path);
             Matcher matcher = new();
             matcher.AddInclude("**/*.info.json");
+            Regex rx = new Regex(Constants.YTCHANNEL_RE, RegexOptions.Compiled | RegexOptions.IgnoreCase);
             string infoPath = "";
             foreach (string file in matcher.GetResultsInFullPath(path))
             {
-                if (Regex.Match(file, Constants.YTCHANNEL_RE).Success)
+                if (rx.IsMatch(file))
                 {
                     infoPath = file;
                     break;
@@ -76,7 +76,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers.LocalMetadata
             }
             _logger.LogDebug("YTLocalSeries HasChanged Result: {Result}", result);
             return result;
-            
+
         }
     }
 }

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/AbstractYoutubeRemoteProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/AbstractYoutubeRemoteProvider.cs
@@ -53,12 +53,9 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
             {
                 result.Item.ProviderIds.Remove(Constants.PluginName);
-                result.Item.ProviderIds.Add(Constants.PluginName, id);
             }
-            else
-            {
-                result.Item.ProviderIds.Add(Constants.PluginName, id);
-            }
+            
+            result.Item.ProviderIds.Add(Constants.PluginName, id);
             return result;
         }
 
@@ -73,12 +70,9 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
             {
                 result.Item.ProviderIds.Remove(Constants.PluginName);
-                result.Item.ProviderIds.Add(Constants.PluginName, id);
             }
-            else
-            {
-                result.Item.ProviderIds.Add(Constants.PluginName, id);
-            }
+
+            result.Item.ProviderIds.Add(Constants.PluginName, id);
             return result;
         }
 
@@ -93,12 +87,8 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
             if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
             {
                 result.Item.ProviderIds.Remove(Constants.PluginName);
-                result.Item.ProviderIds.Add(Constants.PluginName, id);
             }
-            else
-            {
-                result.Item.ProviderIds.Add(Constants.PluginName, id);
-            }
+            result.Item.ProviderIds.Add(Constants.PluginName, id);
             return result;
         }
         public static bool IsFresh(MediaBrowser.Model.IO.FileSystemMetadata fileInfo)

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/AbstractYoutubeRemoteProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/AbstractYoutubeRemoteProvider.cs
@@ -50,7 +50,15 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public static MetadataResult<Movie> YTDLJsonToMovie(YTDLData json, string id)
         {
             var result = Utils.YTDLJsonToMovie(json);
-            result.Item.ProviderIds.Add(Constants.PluginName, id);
+            if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
+            {
+                result.Item.ProviderIds.Remove(Constants.PluginName);
+                result.Item.ProviderIds.Add(Constants.PluginName, id);
+            }
+            else
+            {
+                result.Item.ProviderIds.Add(Constants.PluginName, id);
+            }
             return result;
         }
 
@@ -62,7 +70,15 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public static MetadataResult<MusicVideo> YTDLJsonToMusicVideo(YTDLData json, string id)
         {
             var result = Utils.YTDLJsonToMusicVideo(json);
-            result.Item.ProviderIds.Add(Constants.PluginName, id);
+            if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
+            {
+                result.Item.ProviderIds.Remove(Constants.PluginName);
+                result.Item.ProviderIds.Add(Constants.PluginName, id);
+            }
+            else
+            {
+                result.Item.ProviderIds.Add(Constants.PluginName, id);
+            }
             return result;
         }
 
@@ -74,7 +90,15 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public static MetadataResult<Episode> YTDLJsonToEpisode(YTDLData json, string id)
         {
             var result = Utils.YTDLJsonToEpisode(json);
-            result.Item.ProviderIds.Add(Constants.PluginName, id);
+            if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
+            {
+                result.Item.ProviderIds.Remove(Constants.PluginName);
+                result.Item.ProviderIds.Add(Constants.PluginName, id);
+            }
+            else
+            {
+                result.Item.ProviderIds.Add(Constants.PluginName, id);
+            }
             return result;
         }
         public static bool IsFresh(MediaBrowser.Model.IO.FileSystemMetadata fileInfo)
@@ -84,16 +108,6 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                 return true;
             }
             return false;
-        }
-        /// <summary>
-        ///  Returns the Youtube ID from the file path. Matches last 11 character field inside square brackets.
-        /// </summary>
-        /// <param name="name"></param>
-        /// <returns></returns>
-        public static string GetYTID(string name)
-        {
-            var match = Regex.Match(name, Constants.YTID_RE);
-            return match.Value;
         }
         /// <summary>
         /// Returns path to where metadata json file should be.
@@ -126,7 +140,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         {
             _logger.LogDebug("YTDL GetMetadata: {Path}", info.Path);
             MetadataResult<T> result = new();
-            var id = GetYTID(info.Path);
+            var id = Utils.GetYTID(info.Path);
             if (string.IsNullOrWhiteSpace(id))
             {
                 _logger.LogInformation("YTDL GetMetadata: Youtube ID not found in filename of title: {info.Name}", info.Name);

--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/YTDLSeriesProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/YTDLSeriesProvider.cs
@@ -66,6 +66,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                     _logger.LogError("YTDLSeries GetMetadata: Error parsing json: ");
                     _logger.LogError(video.ToString());
                     _logger.LogError(video.title);
+                    _logger.LogError(e.Message);
                 }
             }
             return result;

--- a/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
@@ -33,12 +33,20 @@ namespace Jellyfin.Plugin.YoutubeMetadata
         /// <returns></returns>
         public static string GetYTID(string name)
         {
-            var match = Regex.Match(name, Constants.YTID_RE);
-            if (!match.Success)
+            var rxc = new Regex(Constants.YTCHANNEL_RE, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            if (rxc.IsMatch(name))
             {
-                match = Regex.Match(name, Constants.YTCHANNEL_RE);
+                MatchCollection match = rxc.Matches(name);
+                return match[0].Groups["id"].ToString();
             }
-            return match.Value;
+
+            var rx = new Regex(Constants.YTID_RE, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            if (rx.IsMatch(name))
+            {
+                MatchCollection match = rx.Matches(name);
+                return match[0].Groups["id"].ToString();
+            }
+            return "";
         }
 
         /// <summary>
@@ -70,7 +78,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             return Path.Combine(dataPath, "ytvideo.info.json");
         }
 
-        public static async Task<string> SearchChannel (string query, IServerApplicationPaths appPaths, CancellationToken cancellationToken)
+        public static async Task<string> SearchChannel(string query, IServerApplicationPaths appPaths, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var ytd = new YoutubeDLP();
@@ -115,11 +123,12 @@ namespace Jellyfin.Plugin.YoutubeMetadata
                 ytd.Options.FilesystemOptions.Cookies = cookie_file;
             }
             await task;
-            
+
+            Regex rx = new Regex(@".*The playlist does not exist\..*", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
             foreach (string err in ytdl_errs)
             {
-                var match = Regex.Match(err, @".*The playlist does not exist\..*");
-                if (match.Success)
+                if (rx.IsMatch(err))
                 {
                     return false;
                 }
@@ -152,14 +161,15 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             ytd.Options.FilesystemOptions.WriteInfoJson = true;
             ytd.Options.VerbositySimulationOptions.SkipDownload = true;
             var cookie_file = Path.Join(appPaths.PluginsPath, "YoutubeMetadata", "cookies.txt");
-            if ( File.Exists(cookie_file) ) {
+            if (File.Exists(cookie_file))
+            {
                 ytd.Options.FilesystemOptions.Cookies = cookie_file;
             }
-            
+
             var dlstring = "https://www.youtube.com/watch?v=" + id;
             var dataPath = Path.Combine(appPaths.CachePath, "youtubemetadata", id, "ytvideo");
             ytd.Options.FilesystemOptions.Output = dataPath;
-            
+
             List<string> ytdl_errs = new();
             ytd.StandardErrorEvent += (sender, error) => ytdl_errs.Add(error);
             var task = ytd.DownloadAsync(dlstring);
@@ -270,6 +280,21 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             result.AddPerson(Utils.CreatePerson(json.uploader, json.channel_id));
             result.Item.IndexNumber = 1;
             result.Item.ParentIndexNumber = 1;
+            if (String.IsNullOrEmpty(json.id))
+            {
+                return result;
+            }
+
+            if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
+            {
+                result.Item.ProviderIds.Remove(Constants.PluginName);
+                result.Item.ProviderIds.Add(Constants.PluginName, json.id);
+            }
+            else
+            {
+                result.Item.ProviderIds.Add(Constants.PluginName, json.id);
+            }
+
             return result;
         }
         /// <summary>

--- a/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
@@ -215,6 +215,19 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             result.Item.ProductionYear = date.Year;
             result.Item.PremiereDate = date;
             result.AddPerson(Utils.CreatePerson(json.uploader, json.channel_id));
+            
+            if (String.IsNullOrEmpty(json.id))
+            {
+                return result;
+            }
+
+            if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
+            {
+                result.Item.ProviderIds.Remove(Constants.PluginName);
+            }
+
+            result.Item.ProviderIds.Add(Constants.PluginName, json.id);
+
             return result;
         }
 
@@ -240,13 +253,23 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             {
                 date = DateTime.ParseExact(json.upload_date, "yyyyMMdd", null);
             }
-            catch
-            {
-
-            }
+            catch { }
             result.Item.ProductionYear = date.Year;
             result.Item.PremiereDate = date;
             result.AddPerson(Utils.CreatePerson(json.uploader, json.channel_id));
+
+            if (String.IsNullOrEmpty(json.id))
+            {
+                return result;
+            }
+
+            if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
+            {
+                result.Item.ProviderIds.Remove(Constants.PluginName);
+            }
+
+            result.Item.ProviderIds.Add(Constants.PluginName, json.id);
+
             return result;
         }
 
@@ -280,6 +303,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             result.AddPerson(Utils.CreatePerson(json.uploader, json.channel_id));
             result.Item.IndexNumber = 1;
             result.Item.ParentIndexNumber = 1;
+
             if (String.IsNullOrEmpty(json.id))
             {
                 return result;
@@ -288,12 +312,9 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             if (result.Item.ProviderIds.ContainsKey(Constants.PluginName))
             {
                 result.Item.ProviderIds.Remove(Constants.PluginName);
-                result.Item.ProviderIds.Add(Constants.PluginName, json.id);
             }
-            else
-            {
-                result.Item.ProviderIds.Add(Constants.PluginName, json.id);
-            }
+
+            result.Item.ProviderIds.Add(Constants.PluginName, json.id);
 
             return result;
         }

--- a/Jellyfin.Plugin.YoutubeMetadata/YTDLData.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/YTDLData.cs
@@ -16,7 +16,8 @@ namespace Jellyfin.Plugin.YoutubeMetadata
     }
     public class YTDLData
     {
-        // Human name
+        // ref id
+        public string id { get; set; }
         public string uploader { get; set; }
         public string upload_date { get; set; }
         // https://github.com/ytdl-org/youtube-dl/issues/1806


### PR DESCRIPTION
Hello,

This pull request add support for providerId to bring it up with the remote provider, right now the local provider only add externalId for series and nothing else like movies, episodes and music videos.

This pull request also contains regex updates to support alternative id format like `[youtube-(id)]`. This format is optional and the original format of `YYYYmmdd title [(id)]` works as expected.