### PR TITLE
Update for jellyfin 10.9

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -9,7 +9,7 @@ on:
     - '**.csproj'
 
 env:
-  DOTNET_VERSION: '6.0.300' # The .NET SDK version to use
+  DOTNET_VERSION: '8.0.104' # The .NET SDK version to use
 
 jobs:
   build:

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/Jellyfin.Plugin.YoutubeMetadata.Tests.csproj
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/Jellyfin.Plugin.YoutubeMetadata.Tests.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.8.0-beta2" />
-    <PackageReference Include="Jellyfin.Data" Version="10.8.0" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Jellyfin.Data" Version="10.*" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="NYoutubeDL" Version="0.11.2" />

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/ProviderTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/ProviderTests.cs
@@ -64,7 +64,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
             _fs.AddFile(@"\cache\youtubemetadata\AAAAAAAAAAA\ytvideo.info.json", new MockFileData(JsonSerializer.Serialize(json)));
             _epInfo.Path = "/Something [AAAAAAAAAAA].mkv";
 
-            //var provider = new YTDLEpisodeProvider(_jf_fs.Object, new Mock<Microsoft.Extensions.Logging.ILogger<YTDLEpisodeProvider>>().Object, _config.Object, _fs);
+            //var provider = new YTDLEpisodeProvider(_jf_fs.Object, new Mock<IHttpClientFactory>().Object, new Mock<Microsoft.Extensions.Logging.ILogger<YTDLEpisodeProvider>>().Object, _config.Object, _fs);
             var metadata = _provider.GetMetadata(_epInfo, _token);
             metadata.Wait();
             Assert.Equal(json.title, metadata.Result.Item.Name);

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/ProviderTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/ProviderTests.cs
@@ -11,6 +11,7 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using System.Net.Http;
+using Jellyfin.Data.Enums;
 
 namespace Jellyfin.Plugin.YoutubeMetadata.Tests
 {
@@ -150,7 +151,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
                         },
                         People = new List<PersonInfo> {new PersonInfo {
                             Name = "ankenyr",
-                            Type = PersonType.Director,
+                            Type = PersonKind.Director,
                             ProviderIds = new Dictionary<string, string> { { "YoutubeMetadata", "abc123" } } }
                         }
                     }
@@ -180,7 +181,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
                         },
                         People = new List<PersonInfo> {new PersonInfo {
                             Name = "ankenyr",
-                            Type = PersonType.Director,
+                            Type = PersonKind.Director,
                             ProviderIds = new Dictionary<string, string> { { "YoutubeMetadata", "abc123" } } }
                         }
                     }
@@ -219,7 +220,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
                         },
                         People = new List<PersonInfo> {new PersonInfo {
                             Name = "ankenyr",
-                            Type = PersonType.Director,
+                            Type = PersonKind.Director,
                             ProviderIds = new Dictionary<string, string> { { "YoutubeMetadata", "abc123" } } }
                         }
                     }

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/ProviderTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/ProviderTests.cs
@@ -8,15 +8,12 @@ using System.IO.Abstractions.TestingHelpers;
 using System.Collections.Generic;
 using System.Text.Json;
 using MediaBrowser.Controller.Entities;
-using MediaBrowser.Model.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using System.Net.Http;
 using Jellyfin.Data.Enums;
 
 namespace Jellyfin.Plugin.YoutubeMetadata.Tests
 {
-
-
     public class YTDLEpisodeProviderTest
     {
         private readonly Moq.Mock<MediaBrowser.Model.IO.IFileSystem> _jf_fs;
@@ -187,6 +184,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
                     }
                 }
         };
+
         [Theory]
         [MemberData(nameof(MusicJsonTests))]
         public void YTDLJsonToMusicVideo(YTDLData json, MetadataResult<MusicVideo> expected)
@@ -226,6 +224,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
                     }
                 }
         };
+
         [Theory]
         [MemberData(nameof(MovieJsonTests))]
         public void YTDLJsonToMovie(YTDLData json, MetadataResult<Movie> expected)
@@ -233,14 +232,5 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
             var result = JsonSerializer.Serialize(YTDLEpisodeProvider.YTDLJsonToMovie(json, "id123"));
             Assert.Equal(JsonSerializer.Serialize(expected), result);
         }
-
-
     }
-
-
-
-
-
-
-
 }

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
@@ -1,17 +1,14 @@
 ﻿using Xunit;
-using Jellyfin.Plugin.YoutubeMetadata;
 using MediaBrowser.Controller.Entities;
-using MediaBrowser.Model.Entities;
 using Newtonsoft.Json;
 using MediaBrowser.Controller;
 using Moq;
 using System.Collections.Generic;
-using System.IO.Abstractions.TestingHelpers;
-using System.Threading;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Entities.Movies;
 using System;
 using Jellyfin.Data.Enums;
+using Jellyfin.Plugin.YoutubeMetadata;
 
 namespace Jellyfin.Plugin.YoutubeMetadata.Tests
 {
@@ -24,8 +21,6 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
         public void GetYTIDTest(string fn, string expected)
         {
             Assert.Equal(expected, Utils.GetYTID(fn));
-
-
         }
 
         [Fact]
@@ -34,9 +29,9 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
             var result = Utils.CreatePerson("3Blue1Brown", "UCYO_jab_esuFRV4b17AJtAw");
             var expected = new PersonInfo { Name = "3Blue1Brown", Type = PersonKind.Director, ProviderIds = new Dictionary<string, string> { { "YoutubeMetadata", "UCYO_jab_esuFRV4b17AJtAw" } } };
 
-
             Assert.Equal(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(result));
         }
+
         [Fact]
         public void GetVideoInfoPathTest()
         {
@@ -190,5 +185,4 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
             Assert.Equal("ABCDEFGHIJKLMNOPQRSTUVWX", result.Item.ProviderIds["YoutubeMetadata"]);
         }
     }
-
 }

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Entities.Movies;
 using System;
+using System.IO;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.YoutubeMetadata;
 
@@ -35,11 +36,10 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
         [Fact]
         public void GetVideoInfoPathTest()
         {
-            // TODO: make path test work on both Windows and Linux
-            var mockAppPath = Mock.Of<IServerApplicationPaths>(a => a.CachePath == @"\foo\bar");
+            var mockAppPath = Mock.Of<IServerApplicationPaths>(a => a.CachePath == Path.Combine("foo", "bar").ToString());
 
             var result = Utils.GetVideoInfoPath(mockAppPath, "id123");
-            Assert.Equal(@"\foo\bar\youtubemetadata\id123\ytvideo.info.json", result);
+            Assert.Equal(Path.Combine("foo", "bar", "youtubemetadata", "id123", "ytvideo.info.json").ToString(), result);
         }
 
         [Fact]

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
@@ -35,8 +35,8 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
         [Fact]
         public void GetVideoInfoPathTest()
         {
-            var mockAppPath = Mock.Of<IServerApplicationPaths>(a =>
-            a.CachePath == @"\foo\bar");
+            // TODO: make path test work on both Windows and Linux
+            var mockAppPath = Mock.Of<IServerApplicationPaths>(a => a.CachePath == @"\foo\bar");
 
             var result = Utils.GetVideoInfoPath(mockAppPath, "id123");
             Assert.Equal(@"\foo\bar\youtubemetadata\id123\ytvideo.info.json", result);
@@ -76,7 +76,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
             Assert.Equal("Foo", result.Item.Name);
             Assert.Equal("Some cool movie!", result.Item.Overview);
             Assert.Equal(2022, result.Item.ProductionYear);
-            Assert.Equal("1/31/2022 12:00:00 AM", result.Item.PremiereDate.ToString());
+            Assert.Equal("1/31/2022 12:00:00 AM", result.Item.PremiereDate.ToString());
             Assert.Equal("SomeGuyIKnow", result.People[0].Name);
             Assert.Equal("ABCDEFGHIJKLMNOPQRSTUVWX", result.People[0].ProviderIds["YoutubeMetadata"]);
         }
@@ -103,7 +103,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
             Assert.Equal("Foo", result.Item.Name);
             Assert.Equal("Some cool movie!", result.Item.Overview);
             Assert.Equal(2022, result.Item.ProductionYear);
-            Assert.Equal("1/31/2022 12:00:00 AM", result.Item.PremiereDate.ToString());
+            Assert.Equal("1/31/2022 12:00:00 AM", result.Item.PremiereDate.ToString());
             Assert.Equal("SomeGuyIKnow", result.People[0].Name);
             Assert.Equal("ABCDEFGHIJKLMNOPQRSTUVWX", result.People[0].ProviderIds["YoutubeMetadata"]);
         }
@@ -131,7 +131,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
             Assert.Equal("Bar", result.Item.Name);
             Assert.Equal("Some cool movie!", result.Item.Overview);
             Assert.Equal(2022, result.Item.ProductionYear);
-            Assert.Equal("1/31/2022 12:00:00 AM", result.Item.PremiereDate.ToString());
+            Assert.Equal("1/31/2022 12:00:00 AM", result.Item.PremiereDate.ToString());
             Assert.Equal("SomeGuyIKnow", result.People[0].Name);
             Assert.Equal("ABCDEFGHIJKLMNOPQRSTUVWX", result.People[0].ProviderIds["YoutubeMetadata"]);
         }
@@ -158,7 +158,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
             Assert.Equal("Foo", result.Item.Name);
             Assert.Equal("Some cool movie!", result.Item.Overview);
             Assert.Equal(2022, result.Item.ProductionYear);
-            Assert.Equal("1/31/2022 12:00:00 AM", result.Item.PremiereDate.ToString());
+            Assert.Equal("1/31/2022 12:00:00 AM", result.Item.PremiereDate.ToString());
             Assert.Equal("SomeGuyIKnow", result.People[0].Name);
             Assert.Equal("ABCDEFGHIJKLMNOPQRSTUVWX", result.People[0].ProviderIds["YoutubeMetadata"]);
             Assert.Equal("20220131-Foo", result.Item.ForcedSortName);

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Controller.Entities.Movies;
 using System;
+using Jellyfin.Data.Enums;
 
 namespace Jellyfin.Plugin.YoutubeMetadata.Tests
 {
@@ -31,7 +32,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
         public void CreatePersonTest()
         {
             var result = Utils.CreatePerson("3Blue1Brown", "UCYO_jab_esuFRV4b17AJtAw");
-            var expected = new PersonInfo { Name = "3Blue1Brown", Type = PersonType.Director, ProviderIds = new Dictionary<string, string> { { "YoutubeMetadata", "UCYO_jab_esuFRV4b17AJtAw" } } };
+            var expected = new PersonInfo { Name = "3Blue1Brown", Type = PersonKind.Director, ProviderIds = new Dictionary<string, string> { { "YoutubeMetadata", "UCYO_jab_esuFRV4b17AJtAw" } } };
 
 
             Assert.Equal(JsonConvert.SerializeObject(expected), JsonConvert.SerializeObject(result));

--- a/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata.Providers.Tests/UtilsTests.cs
@@ -42,7 +42,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
         {
             var mockAppPath = Mock.Of<IServerApplicationPaths>(a =>
             a.CachePath == @"\foo\bar");
-            
+
             var result = Utils.GetVideoInfoPath(mockAppPath, "id123");
             Assert.Equal(@"\foo\bar\youtubemetadata\id123\ytvideo.info.json", result);
         }
@@ -50,12 +50,14 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Tests
         [Fact]
         public void YTDLJsonToMovieTest()
         {
-            var data = new YTDLData {
+            var data = new YTDLData
+            {
                 title = "Foo",
                 description = "Some cool movie!",
                 upload_date = "20220131",
                 uploader = "SomeGuyIKnow",
-                channel_id = "ABCDEFGHIJKLMNOPQRSTUVWX" };
+                channel_id = "ABCDEFGHIJKLMNOPQRSTUVWX"
+            };
             var result = Utils.YTDLJsonToMovie(data);
             var person = new PersonInfo
             {

--- a/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
+++ b/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<RootNamespace>Jellyfin.Plugin.YoutubeMetadata</RootNamespace>
-		<AssemblyVersion>1.0.3.8</AssemblyVersion>
-		<FileVersion>1.0.3.8</FileVersion>
-		<Version>1.0.3.9</Version>
+		<AssemblyVersion>1.0.4.0</AssemblyVersion>
+		<FileVersion>1.0.4.0</FileVersion>
+		<Version>1.0.4.0</Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="Configuration\configPage.html" />
@@ -14,10 +14,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-          <PackageReference Include="Jellyfin.Controller" Version="10.8.0-beta2" />
-          <PackageReference Include="Jellyfin.Data" Version="10.8.0" />
-          <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="6.0.0" />
-          <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
+          <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+          <PackageReference Include="Jellyfin.Data" Version="10.9.*" />
+          <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
+          <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
           <PackageReference Include="NYoutubeDLP" Version="0.12.1" />
           <PackageReference Include="System.IO.Abstractions" Version="14.0.13" />
 	</ItemGroup>

--- a/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
+++ b/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
@@ -14,11 +14,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
-          <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-          <PackageReference Include="Jellyfin.Data" Version="10.9.*" />
-          <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
-          <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-          <PackageReference Include="NYoutubeDLP" Version="0.12.1" />
-          <PackageReference Include="System.IO.Abstractions" Version="14.0.13" />
+		<PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+		<PackageReference Include="Jellyfin.Data" Version="10.9.*" />
+		<PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+		<PackageReference Include="NYoutubeDLP" Version="0.12.1" />
+		<PackageReference Include="System.IO.Abstractions" Version="14.0.13" />
 	</ItemGroup>
 </Project>

--- a/Jellyfin.Plugin.YoutubeMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Plugin.cs
@@ -47,15 +47,16 @@ namespace Jellyfin.Plugin.YoutubeMetadata
         }
     }
 
+    /*
     /// <summary>
     /// Register webhook services.
     /// </summary>
     public class PluginServiceRegistrator : IPluginServiceRegistrator
     {
         /// <inheritdoc />
-        public void RegisterServices(IServiceCollection serviceCollection)
+        public void RegisterServices(IServiceCollection serviceCollection, IServerApplicationHost applicationHost)
         {
             serviceCollection.AddScoped<System.IO.Abstractions.IFileSystem, FileSystem>();
         }
-    }
+    }*/
 }

--- a/Jellyfin.Plugin.YoutubeMetadata/Plugin.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Plugin.cs
@@ -10,6 +10,8 @@ using MediaBrowser.Common.Plugins;
 using MediaBrowser.Model.Plugins;
 using MediaBrowser.Model.Serialization;
 using Microsoft.Extensions.DependencyInjection;
+using MediaBrowser.Controller;
+using MediaBrowser.Controller.Plugins;
 
 namespace Jellyfin.Plugin.YoutubeMetadata
 {
@@ -19,6 +21,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
 
         public override Guid Id => Guid.Parse(Constants.PluginGuid);
         IHttpClientFactory _httpClientFactory;
+
         public Plugin(IApplicationPaths applicationPaths, IXmlSerializer xmlSerializer, IHttpClientFactory httpClientFactory) : base(applicationPaths, xmlSerializer)
         {
             Instance = this;
@@ -34,6 +37,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
 
             return httpClient;
         }
+
         public IEnumerable<PluginPageInfo> GetPages()
         {
             return new[]
@@ -47,7 +51,6 @@ namespace Jellyfin.Plugin.YoutubeMetadata
         }
     }
 
-    /*
     /// <summary>
     /// Register webhook services.
     /// </summary>
@@ -58,5 +61,5 @@ namespace Jellyfin.Plugin.YoutubeMetadata
         {
             serviceCollection.AddScoped<System.IO.Abstractions.IFileSystem, FileSystem>();
         }
-    }*/
+    }
 }

--- a/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
@@ -71,7 +71,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             return Path.Combine(dataPath, "ytvideo.info.json");
         }
 
-        public static async Task<string> SearchChannel (string query, IServerApplicationPaths appPaths, CancellationToken cancellationToken)
+        public static async Task<string> SearchChannel(string query, IServerApplicationPaths appPaths, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
             var ytd = new YoutubeDLP();
@@ -116,7 +116,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
                 ytd.Options.FilesystemOptions.Cookies = cookie_file;
             }
             await task;
-            
+
             foreach (string err in ytdl_errs)
             {
                 var match = Regex.Match(err, @".*The playlist does not exist\..*");
@@ -153,14 +153,15 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             ytd.Options.FilesystemOptions.WriteInfoJson = true;
             ytd.Options.VerbositySimulationOptions.SkipDownload = true;
             var cookie_file = Path.Join(appPaths.PluginsPath, "YoutubeMetadata", "cookies.txt");
-            if ( File.Exists(cookie_file) ) {
+            if (File.Exists(cookie_file))
+            {
                 ytd.Options.FilesystemOptions.Cookies = cookie_file;
             }
-            
+
             var dlstring = "https://www.youtube.com/watch?v=" + id;
             var dataPath = Path.Combine(appPaths.CachePath, "youtubemetadata", id, "ytvideo");
             ytd.Options.FilesystemOptions.Output = dataPath;
-            
+
             List<string> ytdl_errs = new();
             ytd.StandardErrorEvent += (sender, error) => ytdl_errs.Add(error);
             var task = ytd.DownloadAsync(dlstring);

--- a/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
@@ -12,6 +12,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Jellyfin.Data.Enums;
 
 namespace Jellyfin.Plugin.YoutubeMetadata
 {
@@ -52,7 +53,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             return new PersonInfo
             {
                 Name = name,
-                Type = PersonType.Director,
+                Type = PersonKind.Director,
                 ProviderIds = new Dictionary<string, string> { { Constants.PluginName, channel_id }
             },
             };

--- a/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
@@ -3,7 +3,6 @@ using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Entities.Movies;
 using MediaBrowser.Controller.Entities.TV;
 using MediaBrowser.Controller.Providers;
-using MediaBrowser.Model.Entities;
 using NYoutubeDL;
 using System;
 using System.Collections.Generic;
@@ -101,6 +100,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
                 return null;
             }
         }
+
         public static async Task<bool> ValidCookie(IServerApplicationPaths appPaths, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -127,6 +127,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             }
             return true;
         }
+
         public static async Task GetChannelInfo(string id, string name, IServerApplicationPaths appPaths, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -145,6 +146,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             var task = ytd.DownloadAsync(String.Format(Constants.ChannelUrl, id));
             await task;
         }
+
         public static async Task YTDLMetadata(string id, IServerApplicationPaths appPaths, CancellationToken cancellationToken)
         {
             //var foo = await ValidCookie(appPaths, cancellationToken);
@@ -167,6 +169,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             var task = ytd.DownloadAsync(dlstring);
             await task;
         }
+
         /// <summary>
         /// Reads JSON data from file.
         /// </summary>
@@ -274,6 +277,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             result.Item.ParentIndexNumber = 1;
             return result;
         }
+
         /// <summary>
         /// Provides a MusicVideo Metadata Result from a json object.
         /// </summary>
@@ -293,5 +297,4 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             return result;
         }
     }
-
 }

--- a/build.yaml
+++ b/build.yaml
@@ -2,18 +2,14 @@
 name: "YouTube Metadata"
 guid: "b4b4353e-dc57-4398-82c1-de9079e7146a"
 version: "1.0.3.2"
-targetAbi: "10.7.0.0"
+targetAbi: "10.9.1.0"
 owner: "ankenyr"
 overview: "YouTube metadata provider"
 description: "Provides YouTube metadata from the YouTube API and Youtube-dl metadata files."
 category: "Metadata"
 artifacts:
 - "Jellyfin.Plugin.YoutubeMetadata.dll"
-- "Newtonsoft.Json.dll"
-- "Google.Apis.dll"
-- "Google.Apis.Core.dll"
-- "Google.Apis.Auth.dll"
-- "Google.Apis.Auth.PlatformServices.dll"
-- "Google.Apis.YouTube.v3.dll"
+- "NYoutubeDLP.dll"
+- "System.IO.Abstractions.dll"
 changelog: >
   changelog


### PR DESCRIPTION
This makes the plugin work with jellyfin 10.9.

I also formatted the files I worked on.

For the github actions build workflow I only changed DOTNET_VERSION: '8.0.104', which is the version I have installed on my system.

I tried to run and fix the tests but RemoteProviderCachedResultsTest still fails. I believe the reason is that it's trying to read a non-existent FileInfo.