### PR TITLE
Change ProviderName to YouTube

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/ExternalId/YTExternalId.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/ExternalId/YTExternalId.cs
@@ -13,7 +13,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers.ExternalId
             => item is Movie || item is Episode || item is MusicVideo;
 
         public string ProviderName
-            => Constants.PluginName;
+            => "YouTube";
 
         public string Key
             => Constants.PluginName;
@@ -31,7 +31,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers.ExternalId
             => item is Series;
 
         public string ProviderName
-            => Constants.PluginName;
+            => "YouTube";
 
         public string Key
             => Constants.PluginName;


### PR DESCRIPTION
The provider name should be the name of the service it links to, rather than the plugin name.