### PR TITLE
Add ProviderId in utils metadata functions

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/AbstractYoutubeRemoteProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/AbstractYoutubeRemoteProvider.cs
@@ -50,7 +50,6 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public static MetadataResult<Movie> YTDLJsonToMovie(YTDLData json, string id)
         {
             var result = Utils.YTDLJsonToMovie(json);
-            result.Item.ProviderIds.Add(Constants.PluginName, id);
             return result;
         }
 
@@ -62,7 +61,6 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public static MetadataResult<MusicVideo> YTDLJsonToMusicVideo(YTDLData json, string id)
         {
             var result = Utils.YTDLJsonToMusicVideo(json);
-            result.Item.ProviderIds.Add(Constants.PluginName, id);
             return result;
         }
 
@@ -74,7 +72,6 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
         public static MetadataResult<Episode> YTDLJsonToEpisode(YTDLData json, string id)
         {
             var result = Utils.YTDLJsonToEpisode(json);
-            result.Item.ProviderIds.Add(Constants.PluginName, id);
             return result;
         }
         public static bool IsFresh(MediaBrowser.Model.IO.FileSystemMetadata fileInfo)

--- a/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
@@ -210,6 +210,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             result.Item.ProductionYear = date.Year;
             result.Item.PremiereDate = date;
             result.AddPerson(Utils.CreatePerson(json.uploader, json.channel_id));
+            result.Item.ProviderIds.Add(Constants.PluginName, json.id);
             return result;
         }
 
@@ -242,6 +243,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             result.Item.ProductionYear = date.Year;
             result.Item.PremiereDate = date;
             result.AddPerson(Utils.CreatePerson(json.uploader, json.channel_id));
+            result.Item.ProviderIds.Add(Constants.PluginName, json.id);
             return result;
         }
 
@@ -275,6 +277,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             result.AddPerson(Utils.CreatePerson(json.uploader, json.channel_id));
             result.Item.IndexNumber = 1;
             result.Item.ParentIndexNumber = 1;
+            result.Item.ProviderIds.Add(Constants.PluginName, json.id);
             return result;
         }
 

--- a/Jellyfin.Plugin.YoutubeMetadata/YTDLData.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/YTDLData.cs
@@ -16,6 +16,7 @@ namespace Jellyfin.Plugin.YoutubeMetadata
     }
     public class YTDLData
     {
+        public string id { get; set; }
         // Human name
         public string uploader { get; set; }
         public string upload_date { get; set; }


### PR DESCRIPTION
Currently, adding the provider id in the AbstractYoutubeRemoteProvider means, that it doesn't get added when using local metadata from an info.json file.


By instead adding it directly when creating the MetadataResult the provider id is added in all cases.

This is a part of PR #84.