### PR TITLE
Condense Logging

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/YTDLSeriesProvider.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Providers/YoutubeDL/YTDLSeriesProvider.cs
@@ -63,9 +63,10 @@ namespace Jellyfin.Plugin.YoutubeMetadata.Providers
                 }
                 catch (System.ArgumentException e)
                 {
-                    _logger.LogError("YTDLSeries GetMetadata: Error parsing json: ");
-                    _logger.LogError(video.ToString());
-                    _logger.LogError(video.title);
+                    _logger.LogError(e,
+                        "YTDLSeries GetMetadata: Error parsing json: {Video} {Title}",
+                        video.ToString(),
+                        video.title);
                 }
             }
             return result;


### PR DESCRIPTION
Also, uses 'e' so a warning about unused 'e' should be removed.

```
Warning: [...snipped...]/
jellyfin-youtube-metadata-plugin/
Jellyfin.Plugin.YoutubeMetadata/
Providers/
YoutubeDL/
YTDLSeriesProvider.cs(64,49): warning CS0168:
The variable 'e' is declared but never used
```