### PR TITLE
Set PersonInfo ProviderIds to an empty dictionary if channel_id is null

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
+++ b/Jellyfin.Plugin.YoutubeMetadata/Utils.cs
@@ -53,8 +53,10 @@ namespace Jellyfin.Plugin.YoutubeMetadata
             {
                 Name = name,
                 Type = PersonKind.Director,
-                ProviderIds = new Dictionary<string, string> { { Constants.PluginName, channel_id }
-            },
+                ProviderIds = channel_id is null ?
+                        new Dictionary<string, string> {} : new Dictionary<string, string> {
+                                { Constants.PluginName, channel_id }
+                        },
             };
         }
 


### PR DESCRIPTION
Fix exception in library scan, when Emby.Server.Implementations.Library.LibraryManager.SavePeopleMetadataAsync calls SetProviderId with the value of each instance of person.ProviderIds, as per https://github.com/jellyfin/jellyfin/issues/13442, at least currently a non null value is required for each person Provider Ids.

Closes #126 