### PR TITLE
Update to build against both Jellyfin 10.9 and 10.10

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
+++ b/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
@@ -15,7 +15,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-		<PackageReference Include="Jellyfin.Data" Version="10.9.*" />
+		<PackageReference Include="Jellyfin.Data" Version="10.*-*" />
 		<PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="8.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
 		<PackageReference Include="NYoutubeDLP" Version="0.12.1" />


### PR DESCRIPTION
Sync the dependencies between Jellyfin.Controller and Jellyfin.Data.

Closes #128 