### PR TITLE
Increment version to: 1.0.3.13

### DIFF
--- a/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
+++ b/Jellyfin.Plugin.YoutubeMetadata/Jellyfin.Plugin.YoutubeMetadata.csproj
@@ -2,9 +2,9 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<RootNamespace>Jellyfin.Plugin.YoutubeMetadata</RootNamespace>
-		<AssemblyVersion>1.0.3.12</AssemblyVersion>
-		<FileVersion>1.0.3.12</FileVersion>
-		<Version>1.0.3.12</Version>
+		<AssemblyVersion>1.0.3.13</AssemblyVersion>
+		<FileVersion>1.0.3.13</FileVersion>
+		<Version>1.0.3.13</Version>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Remove="Configuration\configPage.html" />

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "YouTube Metadata"
 guid: "b4b4353e-dc57-4398-82c1-de9079e7146a"
-version: "1.0.3.12"
+version: "1.0.3.13"
 targetAbi: "10.9.1.0"
 framework: "net9.0"
 owner: "ankenyr"
@@ -13,6 +13,5 @@ artifacts:
 - "NYoutubeDLP.dll"
 - "System.IO.Abstractions.dll"
 changelog: >
-  #66 Bryan792: Fixed error that prevented local metadata from being used.
-  #105 nalsai: Updated the provider name
-  #107 nalsai: Improved some util methods.
+  #120 tcely: Match a specific YouTube ID for thumbnail
+  #143 mcronce: Jellyfin 10.11 support


### PR DESCRIPTION
Please also create a release and update the manifest in the other repository so that everyone can make use of the improvements via the plugin updating mechanism.

Adding a tag for `1.0.3.12` at 5a43291d520529ffd66243e1773e246a4a32edf8 should help with the tags being too long on windows. You also need to remove any tags that are preventing the checkout job from completing.

```
Error: error: cannot lock ref 
'refs/tags/1.0.3.10-1-gd3c2d1d-1-g1907b3c-1-g8d6cf2b-1-g2abf072-6-g97a7200-1-g1b3abf8-2-g5a43291-1-gcc5a238-4-g2f97946-3-g0d1ea0b-1-g4d17e66-1-g2ed1d64-1-g531020d-3-g2657c14-1-g5040336': 
Unable to create 'D:/a/jellyfin-youtube-metadata-plugin/jellyfin-youtube-metadata-plugin/.git/refs/tags/1.0.3.10-1-gd3c2d1d-1-g1907b3c-1-g8d6cf2b-1-g2abf072-6-g97a7200-1-g1b3abf8-2-g5a43291-1-gcc5a238-4-g2f97946-3-g0d1ea0b-1-g4d17e66-1-g2ed1d64-1-g531020d-3-g2657c14-1-g5040336.lock': 
Filename too long
```